### PR TITLE
(REFACTOR): Use redux toolkit since createStore method is deprecated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1956,6 +1956,17 @@
         "@babel/runtime": "^7.6.2"
       }
     },
+    "@reduxjs/toolkit": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.1.tgz",
+      "integrity": "sha512-Q6mzbTpO9nOYRnkwpDlFOAbQnd3g7zj7CtHAZWz5SzE5lcV97Tf8f3SzOO8BoPOMYBFgfZaqTUZqgGu+a0+Fng==",
+      "requires": {
+        "immer": "^9.0.7",
+        "redux": "^4.1.2",
+        "redux-thunk": "^2.4.1",
+        "reselect": "^4.1.5"
+      }
+    },
     "@restart/hooks": {
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.7.tgz",
@@ -9932,6 +9943,11 @@
         "@babel/runtime": "^7.9.2"
       }
     },
+    "redux-thunk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q=="
+    },
     "regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -10094,6 +10110,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "reselect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.5.tgz",
+      "integrity": "sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ=="
     },
     "resolve": {
       "version": "1.22.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@reduxjs/toolkit": "^1.8.1",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.1.1",
     "@testing-library/user-event": "^13.5.0",

--- a/src/layout/infoPanel.layout.js
+++ b/src/layout/infoPanel.layout.js
@@ -2,10 +2,12 @@ import { useState, useEffect } from "react"
 import axios from "axios"
 import SpinnerLoader from "../components/Spinner"
 import MoviesList from "../components/MoviesList"
-import { createStore } from "redux"
+import { configureStore } from "@reduxjs/toolkit"
 import moviesReducer from "../reducer/reducer"
 
-const store = createStore(moviesReducer)
+const store = configureStore({
+    reducer: moviesReducer
+  })
 
 function InfoPanel () {
     const [loaded, setDataLoaded] = useState(false)


### PR DESCRIPTION
Cómo usar:

Instalar toolkit con:
```
npm install @reduxjs/toolkit
```
Reemplazar `createStore` por `configureStore`:
```
const store = configureStore({
  reducer: moviesReducer
})
```

